### PR TITLE
special case 'c' operator (fix #6)

### DIFF
--- a/lua/anywise_reg/keybinds.lua
+++ b/lua/anywise_reg/keybinds.lua
@@ -35,6 +35,7 @@ end
 M.perform_action = function(prefix, operator, textobject)
     handlers.before_action()
     normal(prefix..operator..remap(textobject))
+    if operator == 'c' then vim.cmd('startinsert') end
     handlers.handle_action(prefix, operator, textobject)
 end
 


### PR DESCRIPTION
Manually puts neovim into insert mode after applying the operation, because `:normal {command}` doesn't do it for us