### PR TITLE
Add stylua config and run

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,0 +1,6 @@
+column_width = 120
+line_endings = "Unix"
+indent_type = "Spaces"
+indent_width = 4
+quote_style = "AutoPreferDouble"
+no_call_parentheses = true

--- a/lua/anywise_reg/autocmds.lua
+++ b/lua/anywise_reg/autocmds.lua
@@ -1,8 +1,8 @@
 local M = {}
 
 M.setup_auto_command = function()
-    vim.cmd('autocmd TextYankPost * :lua require("anywise_reg.handlers").handle_yank_post()')
-    vim.cmd('autocmd BufEnter * :lua require("anywise_reg.keybinds").setup_keymaps()')
+    vim.cmd 'autocmd TextYankPost * :lua require("anywise_reg.handlers").handle_yank_post()'
+    vim.cmd 'autocmd BufEnter * :lua require("anywise_reg.keybinds").setup_keymaps()'
 end
 
 return M

--- a/lua/anywise_reg/cmd.lua
+++ b/lua/anywise_reg/cmd.lua
@@ -7,13 +7,13 @@ end
 
 M.normal = function(str, opts)
     if opts == nil then
-        opts = {noremap = true}
+        opts = { noremap = true }
     end
-    local flag = ''
+    local flag = ""
     if opts.noremap == true then
-        flag = '!'
+        flag = "!"
     end
-    vim.cmd(replace_termcodes("normal"..flag.." "..str))
+    vim.cmd(replace_termcodes("normal" .. flag .. " " .. str))
 end
 
 M.feedkeys = function(str, mode)
@@ -22,7 +22,7 @@ end
 
 M.setup_commands = function()
     if config.register_print_cmd then
-        vim.cmd('command! RegData lua require("anywise_reg.data").print_reg_data()')
+        vim.cmd 'command! RegData lua require("anywise_reg.data").print_reg_data()'
     end
 end
 

--- a/lua/anywise_reg/config.lua
+++ b/lua/anywise_reg/config.lua
@@ -4,19 +4,19 @@ M.config = {
     operators = {},
     textobjects = {},
     paste_keys = {},
-    register_print_cmd = false
+    register_print_cmd = false,
 }
 
 local function product(textobjects)
     if textobjects[1] == nil then
-        return {''}
+        return { "" }
     end
     local textobject = table.remove(textobjects, 1)
     local expanded_textobjects = product(textobjects)
     local new_expanded_textobjects = {}
     for _, start in ipairs(textobject) do
         for _, rest in ipairs(expanded_textobjects) do
-            table.insert(new_expanded_textobjects, start..rest)
+            table.insert(new_expanded_textobjects, start .. rest)
         end
     end
     return new_expanded_textobjects
@@ -26,7 +26,7 @@ local function expand_textobjects()
     local textobjects = M.config.textobjects
     for i, textobject in ipairs(textobjects) do
         if type(textobject) == "string" then
-            textobjects[i] = {textobject}
+            textobjects[i] = { textobject }
         end
     end
     M.config.textobjects = product(textobjects)
@@ -37,9 +37,11 @@ M.register_opts = function(opts)
         opts = {}
     end
     if opts.paste_key ~= nil then
-        print("(anywise-reg) Deprecation warning: Use paste_keys instead of paste_key, "
-            .. "see https://github.com/AckslD/nvim-anywise-reg.lua#configuration")
-        M.config.paste_keys[opts.paste_key] = 'p'
+        print(
+            "(anywise-reg) Deprecation warning: Use paste_keys instead of paste_key, "
+                .. "see https://github.com/AckslD/nvim-anywise-reg.lua#configuration"
+        )
+        M.config.paste_keys[opts.paste_key] = "p"
     end
     for key, value in pairs(opts) do
         M.config[key] = value

--- a/lua/anywise_reg/data.lua
+++ b/lua/anywise_reg/data.lua
@@ -4,7 +4,7 @@ local M = {
 }
 
 local function shift_num_regs()
-    for i=8,1,-1 do
+    for i = 8, 1, -1 do
         M.reg_data[string.format("%d", i + 1)] = M.reg_data[string.format("%d", i)]
     end
 end
@@ -20,24 +20,24 @@ local function update_reg_data(reg_name, content)
     if reg_name ~= '"' then
         M.reg_data['"'] = content -- always update unnamed
     end
-    if operator == 'y' then
-        if reg_name ~= '0' then
-            M.reg_data['0'] = content -- always update 0 on yank
+    if operator == "y" then
+        if reg_name ~= "0" then
+            M.reg_data["0"] = content -- always update 0 on yank
         end
-    elseif string.match('cd', operator) ~= nil then
+    elseif string.match("cd", operator) ~= nil then
         -- TODO this doesn't do the right thing for `x` (and maybe `s`) since these
         -- don't update the numbered register it seems. Not sure how one can know
         -- this from TextYankPost. So the numbered registers will be wrong after doing
         -- `x` or `s`.
         shift_num_regs()
-        if reg_name ~= '1' then
-            M.reg_data['1'] = content -- always update 1 on delete/change
+        if reg_name ~= "1" then
+            M.reg_data["1"] = content -- always update 1 on delete/change
         end
     end
 end
 
 M.update_reg_data = function(reg_name, operator, textobject)
-    update_reg_data(reg_name, {operator = operator, textobject = textobject})
+    update_reg_data(reg_name, { operator = operator, textobject = textobject })
 end
 
 M.print_reg_data = function()

--- a/lua/anywise_reg/handlers.lua
+++ b/lua/anywise_reg/handlers.lua
@@ -1,13 +1,13 @@
 local M = {}
-local cmd = require("anywise_reg.cmd")
-local data = require("anywise_reg.data")
+local cmd = require "anywise_reg.cmd"
+local data = require "anywise_reg.data"
 
 M.before_action = function()
     data.will_handle_action = true
 end
 
 local function get_register(prefix)
-    if prefix == '' then
+    if prefix == "" then
         return '"'
     end
     return string.sub(prefix, 2, 3)
@@ -25,9 +25,9 @@ M.handle_paste = function(prefix, operator)
         -- go to edge of current text object
         cmd.normal("v" .. d.textobject, { noremap = false })
         if operator == "P" then -- if 'P' we paste behind
-            cmd.normal("o")
+            cmd.normal "o"
         end
-        cmd.normal("<Esc>")
+        cmd.normal "<Esc>"
     end
     cmd.normal(prefix .. operator)
 end
@@ -35,7 +35,7 @@ end
 M.handle_yank_post = function()
     local reg_name = vim.v.event.regname
     local operator = vim.v.event.operator
-    if reg_name == '' then
+    if reg_name == "" then
         reg_name = '"'
     end
     if not data.will_handle_action then

--- a/lua/anywise_reg/keybinds.lua
+++ b/lua/anywise_reg/keybinds.lua
@@ -1,31 +1,25 @@
 local M = {}
-local config = require('anywise_reg.config').config
-local handlers = require('anywise_reg.handlers')
-local feedkeys = require('anywise_reg.cmd').feedkeys
+local config = require("anywise_reg.config").config
+local handlers = require "anywise_reg.handlers"
+local feedkeys = require("anywise_reg.cmd").feedkeys
 
 local function set_keymap(lhs, rhs)
-    local opts = {noremap = true}
-    local mode = 'n'
-    vim.api.nvim_buf_set_keymap(
-        0,
-        mode,
-        lhs,
-        rhs,
-        opts
-    )
+    local opts = { noremap = true }
+    local mode = "n"
+    vim.api.nvim_buf_set_keymap(0, mode, lhs, rhs, opts)
 end
 
 local function format_str_args(str_args)
-    local args_str = ''
+    local args_str = ""
     for _, str_arg in ipairs(str_args) do
-        args_str = args_str..[[']]..str_arg..[[', ]]
+        args_str = args_str .. [[']] .. str_arg .. [[', ]]
     end
     return args_str:sub(1, -3)
 end
 
 local function remap(lhs)
-    local rhs = vim.fn.maparg(lhs, 'o')
-    if rhs == '' then
+    local rhs = vim.fn.maparg(lhs, "o")
+    if rhs == "" then
         return lhs
     else
         return rhs
@@ -34,17 +28,17 @@ end
 
 M.perform_action = function(prefix, operator, textobject)
     handlers.before_action()
-    feedkeys(prefix..operator..remap(textobject))
+    feedkeys(prefix .. operator .. remap(textobject))
     handlers.handle_action(prefix, operator, textobject)
 end
 
 local function setup_yank_keymaps(prefix)
     for _, operator in ipairs(config.operators) do
         for _, textobject in ipairs(config.textobjects) do
-            local lhs = prefix..operator..textobject
+            local lhs = prefix .. operator .. textobject
             local rhs = '<Cmd>lua require("anywise_reg.keybinds").perform_action('
-                .. format_str_args({prefix, operator, textobject})
-                .. ')<CR>'
+                .. format_str_args { prefix, operator, textobject }
+                .. ")<CR>"
             set_keymap(lhs, rhs)
         end
     end
@@ -53,8 +47,8 @@ end
 local function setup_paste_keymaps(prefix, key, operator)
     local lhs = prefix .. key
     local rhs = '<Cmd>lua require("anywise_reg.handlers").handle_paste('
-        .. format_str_args({ prefix, operator })
-        .. ')<CR>'
+        .. format_str_args { prefix, operator }
+        .. ")<CR>"
     set_keymap(lhs, rhs)
 end
 

--- a/lua/anywise_reg/setup.lua
+++ b/lua/anywise_reg/setup.lua
@@ -1,7 +1,7 @@
 local M = {}
-local config = require("anywise_reg.config")
-local autocmds = require("anywise_reg.autocmds")  -- TODO can relative import be used?
-local cmd = require("anywise_reg.cmd")
+local config = require "anywise_reg.config"
+local autocmds = require "anywise_reg.autocmds" -- TODO can relative import be used?
+local cmd = require "anywise_reg.cmd"
 
 M.setup = function(opts)
     config.register_opts(opts)


### PR DESCRIPTION
Having a autoformatter with the config checked in is a pretty good idea for open source projects. Neoformat should pick this up automatically and run it.

We should get this started early, no one wants a big format commit in the middle that messes up git-blame

I used this for the config
```
column_width = 120
line_endings = "Unix"
indent_type = "Spaces"
indent_width = 4
quote_style = "AutoPreferDouble"
no_call_parentheses = true
```
I think `no_call_parentheses` is subjective but looks nice and `quote_style` is pretty arbitrary, although the auto variants will try reduce the amount of escapes required so it makes sense 